### PR TITLE
add get users endpoint

### DIFF
--- a/handlers/token_validation_handler.go
+++ b/handlers/token_validation_handler.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"user_service/models"
 
 	"github.com/gin-gonic/gin"
@@ -38,4 +39,18 @@ func (h *UserHandler) ValidateToken(c *gin.Context) error {
 		return err
 	}
 	return nil
+}
+
+func extractBearerToken(authHeader string) (string, error) {
+	if authHeader == "" {
+		return "", fmt.Errorf("missing JWT token")
+	}
+
+	const bearerPrefix = "Bearer "
+	if !strings.HasPrefix(authHeader, bearerPrefix) {
+		return "", fmt.Errorf("expected Bearer authorization header")
+	}
+
+	token := strings.TrimPrefix(authHeader, bearerPrefix)
+	return token, nil
 }

--- a/handlers/token_validation_handler.go
+++ b/handlers/token_validation_handler.go
@@ -1,0 +1,41 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"user_service/models"
+
+	"github.com/gin-gonic/gin"
+)
+
+func (h *UserHandler) ValidateToken(c *gin.Context) error {
+	url := c.Request.URL.String()
+	request := models.AuthRequest{}
+	if err := c.ShouldBindHeader(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"title":    "Bad request",
+			"type":     "about:blank",
+			"status":   http.StatusBadRequest,
+			"detail":   "Missing 'Authorization' header",
+			"instance": url,
+		})
+		return err
+	}
+	token, err := extractBearerToken(request.Token)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"title":    "Bad request",
+			"type":     "about:blank",
+			"status":   http.StatusBadRequest,
+			"detail":   fmt.Sprint("Error: ", err.Error()),
+			"instance": url,
+		})
+		return err
+	}
+	err = h.service.ValidateToken(token)
+	if err, ok := err.(*models.Error); ok {
+		c.JSON(err.Status, err)
+		return err
+	}
+	return nil
+}

--- a/handlers/user_handler.go
+++ b/handlers/user_handler.go
@@ -74,31 +74,8 @@ func (h *UserHandler) HandleLogin(c *gin.Context) {
 }
 
 func (h *UserHandler) GetUsers(c *gin.Context) {
-	request := models.AuthRequest{}
-	if err := c.ShouldBindHeader(&request); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"title":    "Bad request",
-			"type":     "about:blank",
-			"status":   http.StatusBadRequest,
-			"detail":   "Missing header: Authorization: Bearer",
-			"instance": "/users",
-		})
-		return
-	}
-	token, err := extractBearerToken(request.Token)
+	err := h.ValidateToken(c)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"title":    "Bad request",
-			"type":     "about:blank",
-			"status":   http.StatusBadRequest,
-			"detail":   err.Error(),
-			"instance": "/users",
-		})
-		return
-	}
-	err = h.service.ValidateToken(token)
-	if err, ok := err.(*models.Error); ok {
-		c.JSON(err.Status, err)
 		return
 	}
 	users, err := h.service.GetUsers()
@@ -111,16 +88,10 @@ func (h *UserHandler) GetUsers(c *gin.Context) {
 		"users": users,
 	})
 }
+
 func (h *UserHandler) GetUser(c *gin.Context) {
-	request := models.AuthRequest{}
-	if err := c.ShouldBindHeader(&request); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"title":    "Bad request",
-			"type":     "about:blank",
-			"status":   http.StatusBadRequest,
-			"detail":   "Missing header: Authorization: Bearer",
-			"instance": "/user",
-		})
+	err := h.ValidateToken(c)
+	if err != nil {
 		return
 	}
 	id, isPresent := c.Params.Get("id")
@@ -132,22 +103,6 @@ func (h *UserHandler) GetUser(c *gin.Context) {
 			"detail":   "Missing id",
 			"instance": "/user",
 		})
-		return
-	}
-	token, err := extractBearerToken(request.Token)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"title":    "Bad request",
-			"type":     "about:blank",
-			"status":   http.StatusBadRequest,
-			"detail":   err.Error(),
-			"instance": "/user",
-		})
-		return
-	}
-	err = h.service.ValidateToken(token)
-	if err, ok := err.(*models.Error); ok {
-		c.JSON(err.Status, err)
 		return
 	}
 	user, err := h.service.GetUser(id)

--- a/handlers/user_handler.go
+++ b/handlers/user_handler.go
@@ -155,11 +155,6 @@ func (h *UserHandler) GetUser(c *gin.Context) {
 		c.JSON(err.Status, err)
 		return
 	}
-	if user == nil {
-		err, _ := models.UserNotFoundError(id).(*models.Error)
-		c.JSON(err.Status, err)
-		return
-	}
 	c.JSON(http.StatusOK, gin.H{
 		"user": user,
 	})

--- a/handlers/user_handler.go
+++ b/handlers/user_handler.go
@@ -1,10 +1,8 @@
 package handlers
 
 import (
-	"fmt"
 	"log"
 	"net/http"
-	"strings"
 	"user_service/models"
 	"user_service/service"
 
@@ -113,18 +111,4 @@ func (h *UserHandler) GetUser(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"user": user,
 	})
-}
-
-func extractBearerToken(authHeader string) (string, error) {
-	if authHeader == "" {
-		return "", fmt.Errorf("missing JWT token")
-	}
-
-	const bearerPrefix = "Bearer "
-	if !strings.HasPrefix(authHeader, bearerPrefix) {
-		return "", fmt.Errorf("expected Bearer authorization header")
-	}
-
-	token := strings.TrimPrefix(authHeader, bearerPrefix)
-	return token, nil
 }

--- a/init.sql
+++ b/init.sql
@@ -2,7 +2,8 @@ CREATE DATABASE users_db;
 \c users_db
 
 CREATE TABLE IF NOT EXISTS users (
-    email VARCHAR(255) PRIMARY KEY,
+    id SERIAL PRIMARY KEY,
+    email VARCHAR(255),
     name VARCHAR(255),
     type VARCHAR(255),
     password_hash VARCHAR(255),

--- a/mocks/Repository.go
+++ b/mocks/Repository.go
@@ -31,6 +31,36 @@ func (_m *Repository) AddUser(user models.User) error {
 	return r0
 }
 
+// GetUsers provides a mock function with no fields
+func (_m *Repository) GetUsers() ([]models.UserInfo, error) {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUsers")
+	}
+
+	var r0 []models.UserInfo
+	var r1 error
+	if rf, ok := ret.Get(0).(func() ([]models.UserInfo, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() []models.UserInfo); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.UserInfo)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // IsEmailRegistered provides a mock function with given fields: email
 func (_m *Repository) IsEmailRegistered(email string) (bool, error) {
 	ret := _m.Called(email)

--- a/mocks/Repository.go
+++ b/mocks/Repository.go
@@ -31,6 +31,36 @@ func (_m *Repository) AddUser(user models.User) error {
 	return r0
 }
 
+// GetUser provides a mock function with given fields: id
+func (_m *Repository) GetUser(id string) (*models.UserInfo, error) {
+	ret := _m.Called(id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUser")
+	}
+
+	var r0 *models.UserInfo
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (*models.UserInfo, error)); ok {
+		return rf(id)
+	}
+	if rf, ok := ret.Get(0).(func(string) *models.UserInfo); ok {
+		r0 = rf(id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*models.UserInfo)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetUsers provides a mock function with no fields
 func (_m *Repository) GetUsers() ([]models.UserInfo, error) {
 	ret := _m.Called()

--- a/models/error.go
+++ b/models/error.go
@@ -75,3 +75,13 @@ func SessionExpired() error {
 		Detail: "The current session has expired.",
 	}
 }
+
+func UserNotFoundError(id string) error {
+	return &Error{
+		Type:     "about:blank", // TODO: consider setting the right type here
+		Title:    "User not found",
+		Status:   http.StatusNotFound,
+		Detail:   fmt.Sprintf("The user with id %s was not found", id),
+		Instance: fmt.Sprintf("/user/%s", id),
+	}
+}

--- a/models/request.go
+++ b/models/request.go
@@ -4,3 +4,7 @@ type LoginRequest struct {
 	Email    string `json:"email" binding:"required"`
 	Password string `json:"password" binding:"required"`
 }
+
+type AuthRequest struct {
+	Token string `header:"Authorization" binding:"required"`
+}

--- a/models/user.go
+++ b/models/user.go
@@ -8,7 +8,7 @@ type User struct {
 }
 
 type UserInfo struct {
-	Id       int    `json:"id"`
+	Id       string `json:"id"`
 	Name     string `json:"name"`
 	UserType string `json:"userType"`
 }

--- a/models/user.go
+++ b/models/user.go
@@ -6,3 +6,9 @@ type User struct {
 	Password string `json:"password" binding:"required"`
 	UserType string `json:"userType" binding:"required"`
 }
+
+type UserInfo struct {
+	Id       int
+	Name     string
+	UserType string
+}

--- a/models/user.go
+++ b/models/user.go
@@ -8,7 +8,7 @@ type User struct {
 }
 
 type UserInfo struct {
-	Id       int
-	Name     string
-	UserType string
+	Id       int    `json:"id"`
+	Name     string `json:"name"`
+	UserType string `json:"userType"`
 }

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -9,4 +9,5 @@ type Repository interface {
 	AddUser(user models.User) error
 	PasswordMatches(email, password string) (bool, error)
 	UserIsBlocked(email string) (bool, error)
+	GetUsers() ([]models.UserInfo, error)
 }

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -10,4 +10,5 @@ type Repository interface {
 	PasswordMatches(email, password string) (bool, error)
 	UserIsBlocked(email string) (bool, error)
 	GetUsers() ([]models.UserInfo, error)
+	GetUser(id string) (*models.UserInfo, error)
 }

--- a/repository/user_repository.go
+++ b/repository/user_repository.go
@@ -91,7 +91,7 @@ func (r *UserRepository) GetUsers() ([]models.UserInfo, error) {
 	defer rows.Close()
 	users := make([]models.UserInfo, 0)
 	for rows.Next() {
-		var id int
+		var id string
 		var name string
 		var userType string
 		err = rows.Scan(&id, &name, &userType)
@@ -99,10 +99,38 @@ func (r *UserRepository) GetUsers() ([]models.UserInfo, error) {
 			log.Printf("failed to scan row. Error: %s", err)
 			return nil, err
 		}
-		log.Printf("User id = %d", id)
+		log.Printf("User id = %s", id)
 		user := models.UserInfo{Name: name, UserType: userType, Id: id}
 		users = append(users, user)
 		fmt.Printf("user: %v", user)
 	}
 	return users, err
+}
+
+func (r *UserRepository) GetUser(id string) (*models.UserInfo, error) {
+	query := fmt.Sprintf("SELECT name, email, type FROM users WHERE id=%s;", id)
+	rows, err := r.db.Query(query)
+	if err != nil {
+		log.Printf("Failed to query %s. Error: %s", query, err)
+		return nil, err
+	}
+	defer rows.Close()
+
+	// If the query returned at least one row
+	if rows.Next() {
+		var id string
+		var name string
+		var email string
+		var userType string
+		err = rows.Scan(&id, &name, &email, &userType)
+		if err != nil {
+			log.Printf("failed to scan row. Error: %s", err)
+			return nil, err
+		}
+		log.Printf("User id = %s", id)
+		user := models.UserInfo{Name: name, UserType: userType, Id: id}
+		fmt.Printf("user: %v", user)
+		return &user, nil
+	}
+	return nil, nil
 }

--- a/repository/user_repository.go
+++ b/repository/user_repository.go
@@ -108,7 +108,7 @@ func (r *UserRepository) GetUsers() ([]models.UserInfo, error) {
 }
 
 func (r *UserRepository) GetUser(id string) (*models.UserInfo, error) {
-	query := fmt.Sprintf("SELECT name, email, type FROM users WHERE id=%s;", id)
+	query := fmt.Sprintf("SELECT id, name, email, type FROM users WHERE id=%s;", id)
 	rows, err := r.db.Query(query)
 	if err != nil {
 		log.Printf("Failed to query %s. Error: %s", query, err)

--- a/router/router.go
+++ b/router/router.go
@@ -27,6 +27,7 @@ func CreateUserRouter(config *config.Config) (*gin.Engine, error) {
 	router.POST("/users", handler.CreateUser)
 	router.POST("/login", handler.HandleLogin)
 	router.GET("/users", handler.GetUsers)
+	router.GET("/user/:id", handler.GetUser)
 
 	return router, nil
 }

--- a/router/router.go
+++ b/router/router.go
@@ -26,9 +26,7 @@ func CreateUserRouter(config *config.Config) (*gin.Engine, error) {
 	router := gin.Default()
 	router.POST("/users", handler.CreateUser)
 	router.POST("/login", handler.HandleLogin)
-
-	// TODO: remove this, for testing purposes only
-	router.POST("/token", handler.ValidateToken)
+	router.GET("/users", handler.GetUsers)
 
 	return router, nil
 }

--- a/service/service.go
+++ b/service/service.go
@@ -77,3 +77,11 @@ func (s *Service) LoginUser(loginRequest models.LoginRequest) (string, error) {
 	}
 	return token, nil
 }
+
+func (s *Service) GetUsers() ([]models.UserInfo, error) {
+	users, err := s.userRepository.GetUsers()
+	if err != nil {
+		return nil, models.InternalServerError()
+	}
+	return users, nil
+}

--- a/service/service.go
+++ b/service/service.go
@@ -91,5 +91,8 @@ func (s *Service) GetUser(id string) (*models.UserInfo, error) {
 	if err != nil {
 		return nil, models.InternalServerError()
 	}
+	if user == nil {
+		return nil, models.UserNotFoundError(id)
+	}
 	return user, nil
 }

--- a/service/service.go
+++ b/service/service.go
@@ -85,3 +85,11 @@ func (s *Service) GetUsers() ([]models.UserInfo, error) {
 	}
 	return users, nil
 }
+
+func (s *Service) GetUser(id string) (*models.UserInfo, error) {
+	user, err := s.userRepository.GetUser(id)
+	if err != nil {
+		return nil, models.InternalServerError()
+	}
+	return user, nil
+}

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -132,3 +132,65 @@ func TestUserLogin(t *testing.T) {
 		userRepositoryMock.AssertExpectations(t)
 	})
 }
+
+func TestGetUsers(t *testing.T) {
+	userInfo := models.UserInfo{Id: "1", Name: "John Doe", UserType: "alumno"}
+	expectedUsers := []models.UserInfo{userInfo}
+	config := config.Config{}
+
+	t.Run("get users succeeds", func(t *testing.T) {
+		userRepositoryMock := new(mocks.Repository)
+		userRepositoryMock.On("GetUsers").Return(expectedUsers, nil)
+
+		userService, err := service.NewService(userRepositoryMock, &config)
+		assert.NoError(t, err)
+
+		users, err := userService.GetUsers()
+		assert.NoError(t, err)
+		assert.Equal(t, expectedUsers, users)
+		userRepositoryMock.AssertExpectations(t)
+	})
+
+	t.Run("get users fails due to internal server error", func(t *testing.T) {
+		mockError := fmt.Errorf("mock error")
+		userRepositoryMock := new(mocks.Repository)
+		userRepositoryMock.On("GetUsers").Return(nil, mockError)
+
+		userService, err := service.NewService(userRepositoryMock, &config)
+		assert.NoError(t, err)
+
+		users, err := userService.GetUsers()
+		expectedError := models.InternalServerError()
+		assert.Equal(t, expectedError, err)
+		assert.Nil(t, users)
+		userRepositoryMock.AssertExpectations(t)
+	})
+
+	t.Run("get user with ID 1 succeeds", func(t *testing.T) {
+		userRepositoryMock := new(mocks.Repository)
+		userRepositoryMock.On("GetUser", mock.Anything).Return(&userInfo, nil)
+
+		userService, err := service.NewService(userRepositoryMock, &config)
+		assert.NoError(t, err)
+
+		user, err := userService.GetUser("1")
+		assert.NoError(t, err)
+		assert.Equal(t, &userInfo, user)
+		userRepositoryMock.AssertExpectations(t)
+	})
+
+	t.Run("the user with ID 123 was not found", func(t *testing.T) {
+		id := "123"
+		userRepositoryMock := new(mocks.Repository)
+		userRepositoryMock.On("GetUser", mock.Anything).Return(nil, nil)
+
+		userService, err := service.NewService(userRepositoryMock, &config)
+		assert.NoError(t, err)
+
+		user, err := userService.GetUser(id)
+		expectedError := models.UserNotFoundError(id)
+		assert.Equal(t, expectedError, err)
+		assert.Nil(t, user)
+		userRepositoryMock.AssertExpectations(t)
+	})
+}


### PR DESCRIPTION
Agrega los siguientes endpoints:
* GET /users  (devuelve una lista con todos los usuarios registrados)
* GET /user/{id} (devuelve el usuario segun el id). El id no va en el body sino como un param.

Ambos endpoints requieren un token JWT válido en el header `Authorization: Bearer`.

Pendientes:
- [x] unit tests

