### PR TITLE
fix: users database columns order

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -7,9 +7,9 @@ CREATE TABLE IF NOT EXISTS users (
     name VARCHAR(255),
     type VARCHAR(255),
     password_hash VARCHAR(255),
-    blocked_until BIGINT,
     latitude FLOAT,
     longitude FLOAT,
+    blocked_until BIGINT,
     registration_date DATE
 );
 

--- a/repository/user_repository.go
+++ b/repository/user_repository.go
@@ -47,7 +47,7 @@ func (r *UserRepository) AddUser(user models.User) error {
 	passwordHash := hex.EncodeToString(hasher.Sum(nil))
 	blockedUntil := 0
 	date := utils.GetDate()
-	query := fmt.Sprintf("INSERT INTO users VALUES (DEFAULT, '%s', '%s', '%s', '%s', %d, '%f', '%f', '%s');", user.Email, user.Name, user.UserType, passwordHash, blockedUntil, user.Latitude, user.Longitude, date)
+	query := fmt.Sprintf("INSERT INTO users VALUES (DEFAULT, '%s', '%s', '%s', '%s', '%f', '%f', %d, '%s');", user.Email, user.Name, user.UserType, passwordHash, user.Latitude, user.Longitude, blockedUntil, date)
 	_, err := r.db.Exec(query)
 	if err != nil {
 		log.Printf("Failed to query %s. Error: %s", query, err)

--- a/service/service_integration_test.go
+++ b/service/service_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"user_service/models"
 	"user_service/repository"
 	"user_service/service"
+	"user_service/utils"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -226,14 +227,14 @@ func TestIntegration(t *testing.T) {
 	t.Run("get users full info succeeds", func(t *testing.T) {
 		users, err := userService.GetUsersFullInfo()
 		assert.Nil(t, err)
-
+		date := utils.GetDate()
 		expectedUsers := []models.UserFullInfo{
 			{
 				Id:               2,
 				Name:             "John Doe",
 				Email:            "mary@example.com",
 				UserType:         "alumno",
-				RegistrationDate: "2025-05-01",
+				RegistrationDate: date,
 				Latitude:         0,
 				Longitude:        0,
 				Blocked:          false,
@@ -243,7 +244,7 @@ func TestIntegration(t *testing.T) {
 				Name:             "Johnny Doe",
 				Email:            "johnny@example.com",
 				UserType:         "alumno",
-				RegistrationDate: "2025-05-01",
+				RegistrationDate: date,
 				Latitude:         0,
 				Longitude:        0,
 				Blocked:          false,


### PR DESCRIPTION
Al cambiar una de las columnas de la tabla `users` en el servicio corriendo en cloud, se modificó el orden de las columnas, por lo tanto, al intentar agregar nuevas filas a la tabla (durante el registro de usuarios) fallaba porque el tipo de una de las columnas no coincide con el esperado.