### PR TITLE
add authorization checks

### DIFF
--- a/handlers/user_handler.go
+++ b/handlers/user_handler.go
@@ -600,7 +600,7 @@ func (h *UserHandler) NotifyUser(c *gin.Context) {
 }
 
 func (h *UserHandler) SetUserNotificationSettings(c *gin.Context) {
-	_, err := h.ValidateToken(c)
+	token, err := h.ValidateToken(c)
 	if err != nil {
 		return
 	}
@@ -608,6 +608,10 @@ func (h *UserHandler) SetUserNotificationSettings(c *gin.Context) {
 	id, err := strconv.ParseInt(idString, 10, 64)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, models.BadRequestInvalidId(idString, c.Request.URL.Path))
+		return
+	}
+	if token.Id != idString {
+		c.JSON(http.StatusUnauthorized, models.InvalidToken())
 		return
 	}
 

--- a/handlers/user_handler.go
+++ b/handlers/user_handler.go
@@ -656,7 +656,7 @@ func (h *UserHandler) SetUserNotificationSettings(c *gin.Context) {
 }
 
 func (h *UserHandler) GetUserNotificationSettings(c *gin.Context) {
-	_, err := h.ValidateToken(c)
+	token, err := h.ValidateToken(c)
 	if err != nil {
 		return
 	}
@@ -664,6 +664,10 @@ func (h *UserHandler) GetUserNotificationSettings(c *gin.Context) {
 	id, err := strconv.ParseInt(idString, 10, 64)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, models.BadRequestInvalidId(idString, c.Request.URL.Path))
+		return
+	}
+	if token.Id != idString {
+		c.JSON(http.StatusUnauthorized, models.InvalidToken())
 		return
 	}
 	userType, err := h.service.GetUserType(id)

--- a/handlers/user_handler.go
+++ b/handlers/user_handler.go
@@ -340,7 +340,6 @@ func (h *UserHandler) EmailExists(c *gin.Context) {
 func (h *UserHandler) HandleAdminLogin(c *gin.Context) {
 	loginRequest := models.LoginRequest{}
 	if err := c.ShouldBind(&loginRequest); err != nil {
-		log.Print("POST /login Error: Bad request")
 		c.JSON(http.StatusBadRequest, models.BadRequestMissingFields(c.Request.URL.Path))
 		return
 	}
@@ -477,7 +476,7 @@ func (h *UserHandler) SetUserType(c *gin.Context) {
 }
 
 func (h *UserHandler) AddPushToken(c *gin.Context) {
-	_, err := h.ValidateToken(c)
+	token, err := h.ValidateToken(c)
 	if err != nil {
 		return
 	}
@@ -486,6 +485,11 @@ func (h *UserHandler) AddPushToken(c *gin.Context) {
 	id, err := strconv.ParseInt(idString, 10, 64)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, models.BadRequestInvalidId(idString, c.Request.URL.Path))
+		return
+	}
+
+	if token.Id != idString {
+		c.JSON(http.StatusUnauthorized, models.InvalidToken())
 		return
 	}
 

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -1799,6 +1799,20 @@ func TestSetUserNotificationSettings(t *testing.T) {
 		expectedBody := `{"type":"about:blank","title":"Internal server error","status":500,"detail":"Internal server error","instance":"/users"}`
 		SetupRouterSendRequestAndCompareResults(t, userService, request, expectedStatusCode, expectedBody)
 	})
+
+	t.Run("Set user notification settings fails due to mismatching JWT token", func(t *testing.T) {
+		userRepositoryMock := new(mocks.Repository)
+		userRepositoryMock.On("GetUserType", mock.Anything).Return("", mockError)
+		userService, err := service.NewService(userRepositoryMock, &config)
+		assert.NoError(t, err)
+		token, err := userService.IssueToken("3", "docente")
+		assert.NoError(t, err)
+		body, _ := json.Marshal(studentNotificationSettings)
+		request := PutUserNotificationSettingsReq(id, string(body), token)
+		expectedStatusCode := http.StatusUnauthorized
+		expectedBody := `{"type":"about:blank","title":"Invalid token","status":401,"detail":"The given JWT token is invalid","instance":""}`
+		SetupRouterSendRequestAndCompareResults(t, userService, request, expectedStatusCode, expectedBody)
+	})
 }
 
 func TestGetUserNotificationSettings(t *testing.T) {


### PR DESCRIPTION
Agrega chequeos de autorización en los handlers de los endpoints que modifican información de un usuario según su id, para que se chequee que el id coincida con el id del token JWT.