### PR TITLE
fix: `users_push_token` db schema

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -30,7 +30,7 @@ CREATE TABLE IF NOT EXISTS admins (
 INSERT INTO admins VALUES (DEFAULT, 'admin', 'admin', 'd033e22ae348aeb5660fc2140aec35850c4da997') ON CONFLICT DO NOTHING;
 
 CREATE TABLE IF NOT EXISTS users_push_tokens (
-    id INTEGER REFERENCES users (id),
+    id INTEGER REFERENCES users (id) PRIMARY KEY,
     token VARCHAR(255)
 );
 

--- a/repository/user_repository.go
+++ b/repository/user_repository.go
@@ -382,7 +382,7 @@ func (r *UserRepository) SetUserType(id int64, userType string) error {
 }
 
 func (r *UserRepository) AddUserPushToken(id int64, token string) error {
-	query := fmt.Sprintf("INSERT INTO users_push_tokens VALUES (%d, '%s');", id, token)
+	query := fmt.Sprintf("INSERT INTO users_push_tokens VALUES (%d, '%s') ON CONFLICT (id) DO UPDATE SET token = '%s';", id, token, token)
 	_, err := r.db.Exec(query)
 	if err != nil {
 		log.Printf("Failed to query %s. Error: %s", query, err)


### PR DESCRIPTION
La tabla que almacena los Expo push tokens de los usuarios no tiene primary key, lo que hace que se agreguen muchos registros innecesariamente, por cada usuario.

Este PR cambia la tabla para que la columna `id` sea la primary key, y modifica la función de repository que agrega los tokens, para que se pise el token que ya estaba guardado, en lugar de retornar error.